### PR TITLE
Use a timeout for smoother scrolling

### DIFF
--- a/src/GridManager.js
+++ b/src/GridManager.js
@@ -34,13 +34,14 @@
             var scrollLeft = e.target.scrollLeft,
                 scrollTop = e.target.scrollTop;
 
+            grid.adjustScrollLeft(scrollLeft);
+            
             if(scrollTimer){
                 clearTimeout(scrollTimer);
             }
 
             scrollTimer = setTimeout( function(){
-                scrollTimer = null;
-                grid.adjustScrollLeft(scrollLeft);
+                scrollTimer = null;                
                 grid.adjustScrollTop(scrollTop);
             }, 200);
         });

--- a/src/GridManager.js
+++ b/src/GridManager.js
@@ -28,13 +28,21 @@
     };
 
     this.assignGridEventHandlers = function (grid) {
+        var scrollTimer = null;
 
         grid.$viewport.scroll(function (e) {
             var scrollLeft = e.target.scrollLeft,
                 scrollTop = e.target.scrollTop;
 
-            grid.adjustScrollLeft(scrollLeft);
-            grid.adjustScrollTop(scrollTop);
+            if(scrollTimer){
+                clearTimeout(scrollTimer);
+            }
+
+            scrollTimer = setTimeout( function(){
+                scrollTimer = null;
+                grid.adjustScrollLeft(scrollLeft);
+                grid.adjustScrollTop(scrollTop);
+            }, 200);
         });
 
         //resize the grid on parent re-size events


### PR DESCRIPTION
Hi Eric,

I've added a timeout to the scroll event to avoid updating the grid while the user scrolls. Let me know what you think.

Thanks,
Iulian
