### PR TITLE
Attempt at column hiding...

### DIFF
--- a/build/koGrid.debug.js
+++ b/build/koGrid.debug.js
@@ -2,7 +2,7 @@
 * KoGrid JavaScript Library 
 * (c) Eric M. Barnard 
 * License: MIT (http://www.opensource.org/licenses/mit-license.php) 
-* Compiled At: 21:09:39.34 Thu 05/10/2012 
+* Compiled At: 21:20:16.90 Thu 05/10/2012 
 ***********************************************/ 
 (function(window, undefined){ 
  
@@ -2033,6 +2033,8 @@ kg.KoGrid = function (options) {
 
                 column.sortDirection.subscribe(createColumnSortClosure(column));
 
+                column.width.subscribe(createColumnWidthClosure(column));
+                
                 column.filter.subscribe(filterManager.createFilterChangeCallback(column));
 
                 cols.push(column);

--- a/koGrid.debug.js
+++ b/koGrid.debug.js
@@ -2,7 +2,7 @@
 * KoGrid JavaScript Library 
 * (c) Eric M. Barnard 
 * License: MIT (http://www.opensource.org/licenses/mit-license.php) 
-* Compiled At: 21:09:39.34 Thu 05/10/2012 
+* Compiled At: 21:20:16.90 Thu 05/10/2012 
 ***********************************************/ 
 (function(window, undefined){ 
  
@@ -2033,6 +2033,8 @@ kg.KoGrid = function (options) {
 
                 column.sortDirection.subscribe(createColumnSortClosure(column));
 
+                column.width.subscribe(createColumnWidthClosure(column));
+                
                 column.filter.subscribe(filterManager.createFilterChangeCallback(column));
 
                 cols.push(column);

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -387,6 +387,22 @@ kg.KoGrid = function (options) {
                 }
             }
         }
+        
+        var createColumnWidthClosure = function (col) {
+            return function (width) {
+                // try to fix issues with the width of the headers after hiding the last header.
+                self.elementsNeedMeasuring = true;
+                kg.domUtility.measureGrid(self.$root, self);
+                self.refreshDomSizes();
+                self.adjustScrollTop(0, true);
+                
+                // try to fix issues with the rows not re-rendering (doesn't seem to work the first time for some reason)
+                self.update();
+                var rm = self.rowManager;
+                rm.dataSource.notifySubscribers(rm.dataSource());
+                rm.renderedRange.notifySubscribers(rm.renderedRange());
+            }
+        }
 
         if (columnDefs.length > 1) {
 

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -412,6 +412,8 @@ kg.KoGrid = function (options) {
 
                 column.sortDirection.subscribe(createColumnSortClosure(column));
 
+                column.width.subscribe(createColumnWidthClosure(column));
+                
                 column.filter.subscribe(filterManager.createFilterChangeCallback(column));
 
                 cols.push(column);

--- a/src/GridClasses/HeaderCell.js
+++ b/src/GridClasses/HeaderCell.js
@@ -43,6 +43,10 @@
         var dir = self.column.sortDirection() === "asc" ? "desc" : "asc";
         self.column.sortDirection(dir);
     };
+    
+    this.hide = function () {
+        self.column.width(0);
+    };
 
     this.filterHasFocus = ko.observable(false);
 };

--- a/src/Templates/HeaderCellTemplate.js
+++ b/src/Templates/HeaderCellTemplate.js
@@ -1,11 +1,13 @@
 ﻿kg.templates.defaultHeaderCellTemplate = function () {
     var b = new kg.utils.StringBuilder();
 
-    b.append('<div data-bind="click: $data.sort, css: { kgSorted: !$data.noSortVisible() }">');
+    // the $data.column.width() > 0 thing is a hack... it would be better to have a 'visible' observable, but I'm still trying to get this to work first.
+    b.append('<div data-bind="click: $data.sort, css: { kgSorted: !$data.noSortVisible() }, visible: $data.column.width() > 0">');
     b.append('  <span data-bind="text: $data.displayName"></span>');
     b.append('  <img class="kgSortImg" data-bind="visible: $data.noSortVisible" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAJCAYAAAD+WDajAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAadEVYdFNvZnR3YXJlAFBhaW50Lk5FVCB2My41LjEwMPRyoQAAAEFJREFUKFNjYICC+vp6YyDeDcSCMDEwDRRQAuK7QPwfpAAuiSYBkkQoAHLOQAVgEjB6FYrxGBy8OvHaide1+PwJAMBIWUlZ9vlNAAAAAElFTkSuQmCC"/>');
     b.append('  <img class="kgSortImg" data-bind="visible: $data.sortAscVisible" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAJCAYAAAD+WDajAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwgAADsIBFShKgAAAABp0RVh0U29mdHdhcmUAUGFpbnQuTkVUIHYzLjUuMTAw9HKhAAAAPElEQVQoU2NggIL6+npjIN4NxIIwMTANFFAC4rtA/B+kAC6JJgGSRCgAcs5ABWASMHoVw////3HigZAEACKmlTwMfriZAAAAAElFTkSuQmCC"/>');
     b.append('  <img class="kgSortImg" data-bind="visible: $data.sortDescVisible" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAJCAYAAAD+WDajAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwgAADsIBFShKgAAAABp0RVh0U29mdHdhcmUAUGFpbnQuTkVUIHYzLjUuMTAw9HKhAAAAPUlEQVQoU2P4//8/Ay6MUwKkgQJJBnygvr7+DBD/x4JXMQAFlYD4LprkbriBaAoQEjAVQAXGQLwbiAVhYgD6kIBR+tr9IgAAAABJRU5ErkJggg=="/>');
+    b.append('  <span data-bind="click: $data.hide">H</span>');
     b.append('</div>');
     b.append('<div data-bind="visible: $parent.filterVisible">');
     b.append('  <input type="text" data-bind="value: $data.column.filter, valueUpdate: \'afterkeydown\'" style="width: 80%" tabindex="1" />');


### PR DESCRIPTION
Eric,

I don't expect you to accept this pull request as is.  I was hoping you could take a look at it and help me understand what I should be doing in the subscribed action in Grid.js (returned by createColumnWidthClosure()) to handle a width change on a column properly.  A pull request was the easiest way I could think of to collaborate on this - if there's a better way feel free to recommend!

Here's what we're trying to do.  We need a good way to hide columns (permanently is ok for a given population of the grid) for our UI.  This is because we have data that is automatically retrieved but some of the columns are not terribly useful - but only the user will understand which are useful, so we want a quick way for them to hide the "unimportant" columns so that they can look at the data they want to see quickly.

We thought that an easy way to do this would be setting the width to 0 on the columns.  Just setting the observable width didn't seem to be enough (see the code in HeaderCell.js), so we then thought we needed a handler to update the CSS styles.  I did that, but that still didn't seem to be enough.  A few more guesses got me to where we are now, which is definitely not right either.

It seems to work fine after the first time hiding a column, but on the first hide it "loses" the grid rows until you scroll.  This is why I have the "rm.dataSource.notifySubscribers(...)" and "rm.renderedRange.notifySubscribers(...)" stuff in there - in the hopes this would trigger 'filter-like' behavior.

However, I can't seem to get the 'filter-like' behavior to happen on the first time you hide a column (after the data has been rendered once).

Any idea why?  I'm testing on IE9, btw, if that makes a difference.
