### PR TITLE
KoGrid headerStyle binding breaks in IE8

### DIFF
--- a/src/classes/styleProvider.js
+++ b/src/classes/styleProvider.js
@@ -9,7 +9,7 @@
         return { "width": grid.rootDim.outerWidth() + "px", "height": grid.topPanelHeight() + "px" };
     });
     grid.headerStyle = ko.computed(function() {
-        return { "width": (grid.rootDim.outerWidth() - kg.domUtilityService.ScrollW) + "px", "height": grid.config.headerRowHeight + "px" };
+        return { "width": Math.max(0, grid.rootDim.outerWidth() - kg.domUtilityService.ScrollW) + "px", "height": grid.config.headerRowHeight + "px" };
     });
     grid.viewportStyle = ko.computed(function() {
         return { "width": grid.rootDim.outerWidth() + "px", "height": grid.viewportDimHeight() + "px" };


### PR DESCRIPTION
Beucase now the `grid.rootDim.outerWidth` is an observable the  `grid.rootDim.outerWidth() - kg.domUtilityService.ScrollW` can return a negative numbers which **completely breaks the latest (12/11/2012) KoGrid in IE8.**

You can test the effect in IE8 with official sample page: http://ericmbarnard.github.com/KoGrid/#/examples
Or see also this SO issue: http://stackoverflow.com/questions/13828900/invalid-argument-error-in-ie8-using-kogrid
