### PR TITLE
Fixes to unix build.sh so it is compatible with new KoGrid 2.0 build

### DIFF
--- a/build/build-order.txt
+++ b/build/build-order.txt
@@ -25,5 +25,5 @@
 ..\src\classes\searchProvider.js
 ..\src\classes\selectionService.js
 ..\src\classes\styleProvider.js
-..\src\classes\SortService.js
-..\src\classes\DomUtilityService.js
+..\src\classes\sortService.js
+..\src\classes\domUtilityService.js


### PR DESCRIPTION
Though some effort was made to make the unix build.sh compatible with KoGrid 2.x, it failed hard on the new html templates.

This patch fixes that, and does a couple of other small fixes so the build is even closer to the canonical powershell build.
