### PR TITLE
Added mechanism that allows to use function to generate field values

### DIFF
--- a/src/classes/row.js
+++ b/src/classes/row.js
@@ -63,6 +63,15 @@ window.kg.Row = function (entity, config, selectionService) {
     self.afterSelectionChange = config.afterSelectionChangeCallback;
     self.propertyCache = {};
     self.getProperty = function (path) {
-        return self.propertyCache[path] || (self.propertyCache[path] = window.kg.utils.evalProperty(self.entity, path));
+        if(typeof path === "string"){
+            return self.propertyCache[path] || (self.propertyCache[path] = window.kg.utils.evalProperty(self.entity, path));
+        }if(typeof path === "object" && path.alias && path.accessor){
+            var alias = path.alias,
+                accessor = path.accessor;
+            return self.propertyCache[alias] || (self.propertyCache[alias] = accessor(self.entity));
+        }
+        else{
+            console.log("Field definition invalid:", path);
+        }
     };
 }; 


### PR DESCRIPTION
In my project I needed to bind KoGrid to a more complex json structure. Specifically I needed to access arrays and do some other computation that was not possible using simple string based path expressions.

It's now possible to pass a function as field value generator, like this:

{field: {alias: "to", accessor: function(item) {return item.to[0].address}}, displayName: 'To'}

This also allows for different values to be displayed, based on arbitrary conditions.
