### PR TITLE
Fix to issue #199

### DIFF
--- a/koGrid-2.1.1.debug.js
+++ b/koGrid-2.1.1.debug.js
@@ -1106,7 +1106,7 @@ window.kg.Grid = function (options) {
             enableSorting: true,
             maintainColumnRatios: undefined,
             beforeSelectionChange: function () { return true;},
-            afterSelectionChange: function () { },
+            afterSelectionChange: function () { return true;},
             columnsChanged: function() { },
             rowTemplate: undefined,
             headerRowTemplate: undefined,


### PR DESCRIPTION
When trying to set checkbox the toggleSelected return undefined value, stopping the check event chain and thereby isn't the checkbox "visually set".

Fix for this problem was to make the following change (line 1109)

from: afterSelectionChange: function () { },
to: afterSelectionChange: function () { return true; },

since the return statement on line 1633:
return self.afterSelectionChange(self, event);
returns undefined without the "fix" and causing the mentioned problem.
