### PR TITLE
Fix to correct dateRE is undefined

### DIFF
--- a/koGrid-2.1.1.debug.js
+++ b/koGrid-2.1.1.debug.js
@@ -1938,7 +1938,7 @@ window.kg.sortService = {
         } 
         // now lets string check..
         //check if the item data is a valid number
-        if (item.match(/^-?[£$¤]?[\d,.]+%?$/)) {
+        if (item.match(/^-?[ï¿½$ï¿½]?[\d,.]+%?$/)) {
             return window.kg.sortService.sortNumberStr;
         } 
         // check for a date: dd/mm/yyyy or dd/mm/yy
@@ -2064,7 +2064,7 @@ window.kg.sortService = {
             d = '0' + d;
         }
         dateA = y + m + d;
-        mtch = b.match(dateRE);
+        mtch = b.match(window.kg.sortService.dateRE);
         y = mtch[3];
         d = mtch[2];
         m = mtch[1];


### PR DESCRIPTION
Uncaught reference error when sorting by date (Line 133). Found that KOGrid was trying to call 'dateRE' instead of 'window.kg.sortService.dateRE'.
