### PR TITLE
Update link to gh-pages site

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ko.applyBindings(vm);
 Check out the [Getting Started](https://github.com/ericmbarnard/KoGrid/wiki/Getting-Started) and other [Docs](https://github.com/ericmbarnard/KoGrid/wiki)
 
 ##Examples##
-http://ericmbarnard.github.com/KoGrid/#/examples
+http://knockout-contrib.github.io/KoGrid/#/examples
 
 also check out the new [Custom Cell Template Library](https://github.com/ericmbarnard/KoGrid/wiki/Cell-Template-Library)
 ##Change Log##


### PR DESCRIPTION
The examples page linked to ericmbernard's fork which returns a 404, fixed the link to point to the gh-pages of knockout-contrib which is more up-to-date
