### PR TITLE
If sortInfo is passed in, sort by that column initially

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -277,6 +277,15 @@ window.kg.Grid = function (options) {
         self.maxCanvasHt(self.calcMaxCanvasHeight());
         self.searchProvider.evalFilter();
         self.refreshDomSizes();
+        
+        if (self.sortInfo() && self.sortInfo().field) {
+            var col = ko.utils.arrayFirst(self.columns(), function (c) { return c.field === self.sortInfo().field });
+            if (col && col.sort) {
+                setTimeout(function () {
+                    col.sort();
+                }, 0);
+            }
+        }
     };
     self.prevScrollTop = 0;
     self.prevScrollIndex = 0;


### PR DESCRIPTION
Per [the documentation](http://knockout-contrib.github.io/KoGrid/#/api), passing `sortInfo` in the options should set the default sorting state.  However, nothing is looking at the value that is initially passed in.

This patch looks to see if the `sortInfo` has a `field`, when the grid is initialized.  If so, it calls the `sort` method of that column.  However, this sets the column direction, but the sorting is overwritten later during some other initialization.  To combat that, I've wrapped the `sort` call in a `setTimeout`.

This fixes #244 and #74
